### PR TITLE
se quito el boton de restablecer ejemplos

### DIFF
--- a/SitePages/patients.html
+++ b/SitePages/patients.html
@@ -78,9 +78,9 @@
             </div>
             <div class="buttons-wrapper ml-auto">
               <a href="agregar_paciente.html" class="btn btn-dark-red-f-gr"><i class="las la-file-medical"></i>Nueva Evaluación Terapéutica</a>
-              <button class="btn btn-outline-secondary btn-sm ml-2" onclick="restablecerDatosEjemplo()" title="Restablecer datos de ejemplo">
+              <!-- <button class="btn btn-outline-secondary btn-sm ml-2" onclick="restablecerDatosEjemplo()" title="Restablecer datos de ejemplo">
                 <i class="las la-redo"></i> Restablecer Ejemplos
-              </button>
+              </button> -->
             </div>
           </div>
           


### PR DESCRIPTION
This pull request makes a minor update to the `SitePages/patients.html` file by commenting out the "Restablecer Ejemplos" button in the page header. No other functional or structural changes are included.